### PR TITLE
Start cache with Supervisors.

### DIFF
--- a/lib/lazy_cache.ex
+++ b/lib/lazy_cache.ex
@@ -18,8 +18,8 @@ defmodule Rivet.Utils.LazyCache do
 
       Returns `{:ok, PID}`.
       """
-      @spec start() :: {atom, pid}
-      def start() do
+      @spec start_link(term()) :: {atom, pid}
+      def start_link(_) do
         GenServer.start_link(__MODULE__, %{})
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Rivet.Utils.MixProject do
       {:mix_test_watch, "~> 0.8", only: [:test, :dev], runtime: false},
       {:excoveralls, "~> 0.14", only: :test},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
-      {:transmogrify, "~> 1.0"},
+      {:transmogrify, "~> 1.1"},
       {:ecto, "~> 3.7"},
       {:jason, "~> 1.0"},
       {:timex, "~> 3.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Rivet.Utils.MixProject do
       {:mix_test_watch, "~> 0.8", only: [:test, :dev], runtime: false},
       {:excoveralls, "~> 0.14", only: :test},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
-      {:transmogrify, "~> 1.0.0"},
+      {:transmogrify, "~> 1.0"},
       {:ecto, "~> 3.7"},
       {:jason, "~> 1.0"},
       {:timex, "~> 3.0"},


### PR DESCRIPTION
Supervisor expects a `start_link/1`, not `start/0`.